### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/EndLockout/data/questions/end_lockout_letter.yml
+++ b/docassemble/EndLockout/data/questions/end_lockout_letter.yml
@@ -445,7 +445,7 @@ question: |
   % if knows_landlord_name == False:
   Do you know your landlord's address?
   % else:
-  Do you know ${ landlords[0].name.full(middle="full") }'s address?  
+  Do you know ${ landlords[0].name_full() }'s address?  
   % endif
 field: knows_landlord_address
 choices:
@@ -457,7 +457,7 @@ question: |
   % if knows_landlord_name == False:
   What is the landlord's address?
   % else:
-  What is ${ landlords[0].name.full(middle="full") }'s address?  
+  What is ${ landlords[0].name_full() }'s address?  
   % endif
 subquestion: |
   This address will appear on the letter. You can mail or deliver your letter to this address. 
@@ -526,7 +526,7 @@ subquestion: |
   Use the mouse or touchpad on your computer or sign with your finger on your phone.
 signature: user.signature
 under: |
-  ${ user.name.full(middle="full") }
+  ${ user.name_full() }
 ---
 id: forms assembling
 continue button field: forms_assembling
@@ -659,7 +659,7 @@ review:
   - Edit: landlords[0].name.first
     button: |
   	  **Landlord name:**
-      ${landlords[0].name.full(middle="full")}
+      ${landlords[0].name_full()}
     show if: knows_landlord_name
   - Edit: knows_landlord_address
     button: |
@@ -673,7 +673,7 @@ review:
   - Edit: user.name.first
     button: |
       **Your name:**
-      ${user.name.full(middle="full")}
+      ${user.name_full()}
   - Edit: include_phone
     button: |
       **Do you want to list your phone number on the letter?**
@@ -771,7 +771,7 @@ review:
   - Edit: landlords[0].name.first
     button: |
   	  **Landlord name:**
-      ${landlords[0].name.full(middle="full")}
+      ${landlords[0].name_full()}
     show if: knows_landlord_name
   - Edit: knows_landlord_address
     button: |
@@ -794,7 +794,7 @@ review:
   - Edit: user.name.first
     button: |
       **Your name:**
-      ${user.name.full(middle="full")}
+      ${user.name_full()}
   - Edit: include_phone
     button: |
       **Do you want to list your phone number on the letter?**


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>